### PR TITLE
Throw out all pending updates on start

### DIFF
--- a/UserVerificator/UserVerificator.cs
+++ b/UserVerificator/UserVerificator.cs
@@ -23,7 +23,8 @@ using var cts = new CancellationTokenSource();
 // StartReceiving does not block the caller thread. Receiving is done on the ThreadPool.
 var receiverOptions = new ReceiverOptions
 {
-    AllowedUpdates = Array.Empty<UpdateType>() // receive all update types
+    AllowedUpdates = Array.Empty<UpdateType>(), // receive all update types
+    ThrowPendingUpdates = true
 };
 
 botClient.StartReceiving(


### PR DESCRIPTION
Set ThrowPendingUpdates to true, in order to throw out all pending updates on start.
for more info, search 'ThrowPendingUpdates ' [in this readme file.](https://github.com/TelegramBots/Telegram.Bot.Extensions.Polling#telegrambotextensionspolling)